### PR TITLE
Add reconciliation worker coexistence and event-driven proposal

### DIFF
--- a/plans/rewrite/open_decisions.md
+++ b/plans/rewrite/open_decisions.md
@@ -1,7 +1,7 @@
 # Open Decisions Register
 
-Status: Resolved (all listed decisions approved)
-Last updated: 2026-02-09
+Status: Active
+Last updated: 2026-02-12
 
 ## 1. Purpose
 
@@ -16,6 +16,7 @@ Track planning decisions that block or materially change implementation sequenci
 | D-003 | DB exception governance | approved | db-architecture | 2026-02-20 | Policy exists in `db_migration_policy.md`; approvers/process now documented in backlog/gates | Require explicit migration exception record + designated approvers before non-additive changes | Risk of untracked breaking schema changes during mixed runtime |
 | D-004 | Operational CLI tooling disposition | approved | release-management | 2026-02-20 | `operational_tooling_plan.md` + tooling inventory identify scripts requiring disposition | Treat tooling scripts as `retire-approved` by default unless transition-period exception is approved | Python dependency may linger and block retirement gate |
 | D-005 | Repo mirror implementation path (`skopeo` subprocess vs Go `containers/image`) | approved | registry-platform | 2026-02-09 | User approved Go-native migration on 2026-02-09; source anchor: `util/repomirror/skopeomirror.py` | Migrate to Go-native `containers/image`; keep temporary compatibility fallback only during transition testing | Mirror/image workstreams proceed with finalized dependency direction |
+| D-006 | `reconciliationworker` architecture: polling vs event-driven | open | billing-entitlements | TBD | Python worker polls all active users every 5 minutes, making O(users) external API calls (Stripe retrieve + marketplace lookup/create) per cycle. Stripe webhooks and billing API mutations already provide real-time signals for subscription changes. No idempotency keys on marketplace `create_entitlement` or Stripe `Customer.create` calls. Source anchors: `workers/reconciliationworker.py`, `util/marketplace.py`, `endpoints/api/billing.py`, `endpoints/webhooks.py` | Replace full-table polling with event-driven reconciliation triggered by Stripe webhooks and billing API mutations, plus a reduced-frequency sweep (hourly/daily) as a consistency catch-up for out-of-band changes. Add idempotency keys to marketplace and Stripe write calls in Go implementation. See `workers_inventory.md` §9 for detailed proposal. | If deferred: Go port inherits O(users) polling overhead, no idempotency guarantees on external billing API calls, and unnecessarily wide duplicate-call window during coexistence |
 
 ## 3. Resolution rules
 

--- a/plans/rewrite/workers_inventory.md
+++ b/plans/rewrite/workers_inventory.md
@@ -78,6 +78,7 @@ Control-model note:
 3. Queue workers depend on `QueueWorker` watchdog + `extend_processing` semantics.
 4. Worker startup is guarded by feature flags and runtime conditions (account recovery mode, readonly/disable pushes, storage engine checks).
 5. Supervisor service-level toggles (`QUAY_SERVICES`, `QUAY_OVERRIDE_SERVICES`) and feature toggles both influence runtime behavior and must be represented in Go cutover controls.
+6. `reconciliationworker` acquires a Redis global lock before executing. During Python/Go coexistence, this lock provides a runtime safety net against concurrent reconciliation runs — both workers can be deployed simultaneously and the lock guarantees mutual exclusion. The Go implementation must use the exact same Redis key, TTL, renewal, and release pattern as Python. The `WORKER_OWNER_RECONCILIATIONWORKER` switch remains the intentional operational control for which runtime should run, but the Redis lock prevents duplicate external API calls (Stripe/marketplace) even if both workers are accidentally active. Verify the lock key and semantics from the Python source before Go implementation.
 
 ## 6. Migration policy per process
 
@@ -105,7 +106,79 @@ Cross-plan dependencies:
 - Storage and mirror dependencies: `plans/rewrite/storage_backend_inventory.md`
 - Deployment/runtime execution model: `plans/rewrite/deployment_architecture.md`
 
-## 8. Config drift disposition (closed)
+## 9. Reconciliation worker: event-driven migration proposal (D-006)
+
+Decision: `plans/rewrite/open_decisions.md` D-006
+
+### 9.1 Problem
+
+The Python `reconciliationworker` polls every 5 minutes, iterating all active users and making external API calls (Stripe `Customer.retrieve` + marketplace `lookup_subscription` / `create_entitlement`) per user. This has several issues:
+
+1. **Unnecessary load**: The vast majority of users' billing state has not changed. O(users) external API calls per cycle is disproportionate.
+2. **No idempotency**: Neither marketplace `create_entitlement` (POST to `/subscription/v5/createPerm`) nor Stripe `Customer.create` pass idempotency keys. If a call succeeds but the response times out, the next cycle retries without deduplication.
+3. **Unsafe mutation pattern**: Billing API endpoints follow a create-externally-then-save-to-DB pattern (`billing.Customer.create()` → `user.stripe_id = cus.id` → `user.save()`). If the DB save fails after the external call succeeds, the external resource is orphaned.
+4. **Coexistence risk window**: During Python/Go coexistence, more frequent polling increases the chance of edge-case duplicate calls even with the Redis lock in place (lock TTL expiry, network partition).
+
+### 9.2 Existing event sources
+
+Quay already receives real-time billing change signals:
+
+| Event source | Trigger | Current handler | Reconciliation action needed |
+|---|---|---|---|
+| Stripe webhook `checkout.session.completed` | User completes checkout | `endpoints/webhooks.py` — sends email | Reconcile entitlement for this user |
+| Stripe webhook `customer.subscription.created` | New subscription | `endpoints/webhooks.py` — sends email | Reconcile entitlement for this user |
+| Stripe webhook `customer.subscription.updated` | Plan change | `endpoints/webhooks.py` — sends email | Reconcile entitlement for this user |
+| Stripe webhook `customer.subscription.deleted` | Cancellation | `endpoints/webhooks.py` — sends email | Remove/downgrade entitlement for this user |
+| Billing API `POST /v1/user/plan` | User creates plan | `endpoints/api/billing.py` | Reconcile entitlement for this user |
+| Billing API `PUT /v1/user/plan` | User changes plan | `endpoints/api/billing.py` | Reconcile entitlement for this user |
+| Billing API `POST /v1/organization/<orgname>/marketplace` | SKU binding | `endpoints/api/billing.py` | Reconcile entitlement for this org |
+
+### 9.3 Proposed Go architecture
+
+Replace the full-table polling worker with two components:
+
+**A. Event-driven per-user reconciliation**
+
+When a Stripe webhook or billing API mutation occurs, enqueue a reconciliation job for the specific user/org affected. The reconciliation logic (lookup customer, check entitlements, create if missing) remains the same but runs only for the affected entity.
+
+Implementation options:
+- Use the existing queue infrastructure (new `entitlement_reconciliation` queue) with the standard `QueueWorker` pattern.
+- Or handle inline in the webhook/API handler if the marketplace API calls are fast enough (sub-second with 20s timeout).
+
+Benefits:
+- Reconciliation happens within seconds of the billing event, not up to 5 minutes later.
+- External API calls reduced from O(users) per cycle to O(events) per cycle.
+- Idempotency is simpler — the event payload identifies the exact user, and the reconciliation logic can check-then-act for a single entity with a much narrower race window.
+
+**B. Low-frequency consistency sweep**
+
+Keep a full-table reconciliation sweep but reduce frequency to hourly or daily. This catches:
+- Out-of-band subscription changes made directly in the Red Hat portal (no webhook from Quay's perspective).
+- Missed or failed webhook deliveries.
+- Drift from any other source.
+
+This sweep is the safety net, not the primary reconciliation path.
+
+**C. Idempotency improvements**
+
+Regardless of whether event-driven migration is adopted:
+- Add idempotency keys to Stripe `Customer.create` calls (Stripe supports `Idempotency-Key` header natively).
+- Verify whether Red Hat marketplace `createPerm` endpoint supports idempotency keys or has server-side deduplication for duplicate customer+SKU pairs. Document the finding.
+- Add request correlation IDs to marketplace API calls for traceability.
+
+### 9.4 Compatibility and rollback
+
+- During coexistence, the Python poller can remain active as the consistency sweep while Go handles event-driven reconciliation. The Redis lock prevents concurrent execution of the sweep.
+- Rollback: disable Go event-driven handlers, re-enable Python 5-minute poller via `WORKER_OWNER_RECONCILIATIONWORKER=python`. No data migration required — both approaches read the same Stripe/marketplace state.
+- The event-driven approach does not change the database schema or the external API contracts. It changes only when and how often the same reconciliation logic runs.
+
+### 9.5 Scope decision required
+
+This proposal goes beyond strict parity. The team must decide:
+- **Option A**: Port the 5-minute poller as-is for parity, track event-driven migration as a separate follow-up.
+- **Option B (recommended)**: Implement event-driven reconciliation as part of the Go worker migration (WS5/P3), since the webhook handlers are being migrated anyway (WS4) and the integration point is natural.
+
+## 10. Config drift disposition (closed)
 
 `ip-resolver-update-worker` disposition is approved:
 - remove stale service-map references and mark retired (`retired-approved`).


### PR DESCRIPTION
## Summary

- Document the Redis global lock on `reconciliationworker` as a coexistence safety mechanism during Python/Go dual-runtime, requiring the Go implementation to match exact lock semantics (key, TTL, release pattern)
- Register D-006 in the open decisions register: propose replacing the 5-minute full-table polling reconciliation with event-driven reconciliation triggered by Stripe webhooks and billing API mutations that already flow into Quay
- Detail idempotency gaps in Stripe (`Customer.create` with no `Idempotency-Key`) and marketplace (`create_entitlement` with no deduplication) API calls
- Propose a low-frequency consistency sweep (hourly/daily) as a safety net for out-of-band subscription changes
- Present two options for team decision: Option A (parity port of poller) vs Option B (event-driven migration during WS5/P3)

## Files changed

- `plans/rewrite/workers_inventory.md` — added §5.6 (Redis lock coexistence note) and §9 (full event-driven proposal with problem statement, event source mapping, architecture, compatibility/rollback, and scope decision)
- `plans/rewrite/open_decisions.md` — added D-006 with evidence, recommended default, and impact assessment

## Context

Identified during review of the rewrite plan from the perspective of marketplace workers, billing, deployment/CI, and registry. The reconciliation worker's current design makes O(users) external API calls every 5 minutes without idempotency keys — the Go rewrite is the natural point to address this.

## Test plan

- [ ] Review proposal against actual `workers/reconciliationworker.py` source
- [ ] Verify Red Hat marketplace `createPerm` server-side deduplication behavior
- [ ] Team decision on Option A vs Option B at review meeting
- [ ] If Option B approved, update worker migration tracker (PROC-029) trigger type from `scheduled/polling` to `event-driven + sweep`

🤖 Generated with [Claude Code](https://claude.com/claude-code)